### PR TITLE
Update max-packetcache-entries setting doc

### DIFF
--- a/pdns/recursordist/docs/settings.rst
+++ b/pdns/recursordist/docs/settings.rst
@@ -1250,8 +1250,7 @@ Maximum number of simultaneous MTasker threads.
 -  Integer
 -  Default: 500000
 
-Maximum number of Packet Cache entries. Each worker and each distributor thread has a packet cache instance.
-This number will be divided by the number of worker plus the number of distributor threads to compute the maximum number of entries per cache instance.
+Maximum number of Packet Cache entries. Sharded and shared by all threads since 4.9.0.
 
 .. _setting-max-qperq:
 


### PR DESCRIPTION
Since 4.9.0, the packet cache is sharded and shared by all threads.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
